### PR TITLE
Add plan for astro twig plugin

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,5 +1,27 @@
 ## Overview
-
+A proposed Astro plugin will allow Drupal Single Directory Components (SDCs) written in Twig to be consumed directly by an Astro site. The plugin should make Twig components available just like any other component type so they can be imported into `.astro` or `.js` files. Depending on how easily the templates can be precompiled, the plugin may either compile templates at build time or render them at runtime. It also needs to replicate Drupal's custom Twig loader behaviour so that includes and extends resolve correctly.
 
 ## Steps
-
+1. **Research existing tooling**
+   - Review Drupal's SDC format and how it organizes Twig files, YAML metadata, CSS, and JS.
+   - Evaluate Node packages for compiling or rendering Twig (e.g. `twig` or `drupal-twig`) and identify how to hook custom loaders.
+2. **Create an Astro integration skeleton**
+   - Scaffold a new package with `astro add` conventions, exposing a default function that registers hooks.
+   - Provide options to configure component directories and whether to precompile at build or runtime.
+3. **Implement a Twig loader**
+   - Reproduce Drupal's loader logic so templates can `include` or `extend` other SDC files using component-relative paths.
+   - Offer a way to register additional lookup paths (modules, themes, etc.).
+4. **Build‑time compilation**
+   - In the integration's `build:setup` and `build:ssr` hooks, compile Twig to HTML when component props are known at build time.
+   - Cache compiled templates to speed up repeated builds.
+5. **Runtime rendering fallback**
+   - When props are only available at runtime, emit a small wrapper component that loads and renders the Twig template with the loader.
+   - Ensure that hydration and Astro island behaviour are preserved.
+6. **Importing Twig components**
+   - Allow syntax such as `import Card from "./components/card/card.twig";` in `.astro` or `.js` files.
+   - Expose props to the Twig template just like other Astro components.
+7. **Testing and examples**
+   - Provide example SDCs and usage snippets within the repo.
+   - Add tests covering build and runtime scenarios to ensure loader paths resolve correctly.
+8. **Documentation**
+   - Document installation, configuration options, and any limitations.


### PR DESCRIPTION
## Summary
- flesh out PLAN.md with details on building an astro plugin to consume Drupal SDC Twig components

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68471e2880ec8321a027e7c5c39cc692