### PR TITLE
Add full SDC support and nesting test

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -25,6 +25,9 @@ A proposed Astro plugin will allow Drupal Single Directory Components (SDCs) wri
    - Add tests covering build and runtime scenarios to ensure loader paths resolve correctly.
 8. **Documentation**
    - Document installation, configuration options, and any limitations.
+9. **Nested SDC invocation**
+   - Allow one SDC to call another directly, enabling components to be rendered
+     from within Twig templates rather than solely through slot content.
 
 ## Progress
 ### Step 1: Research existing tooling

--- a/example/components/button/button.css
+++ b/example/components/button/button.css
@@ -1,0 +1,1 @@
+.button { color: red; }

--- a/example/components/button/button.js
+++ b/example/components/button/button.js
@@ -1,0 +1,1 @@
+console.log('button js');

--- a/example/components/button/button.twig
+++ b/example/components/button/button.twig
@@ -1,0 +1,1 @@
+<a class="button" href="{{ url }}">{{ label }}</a>

--- a/example/components/button/component.yml
+++ b/example/components/button/component.yml
@@ -1,0 +1,11 @@
+props:
+  label:
+    type: string
+  url:
+    type: string
+slots: {}
+libraries:
+  css:
+    - button.css
+  js:
+    - button.js

--- a/example/components/card.twig
+++ b/example/components/card.twig
@@ -1,1 +1,0 @@
-<div class="card">{{ title }}</div>

--- a/example/components/card/card.css
+++ b/example/components/card/card.css
@@ -1,0 +1,1 @@
+.card { border: 1px solid #000; }

--- a/example/components/card/card.js
+++ b/example/components/card/card.js
@@ -1,0 +1,1 @@
+console.log('card js');

--- a/example/components/card/card.twig
+++ b/example/components/card/card.twig
@@ -1,0 +1,6 @@
+<div class="card">
+  <header>{{ slots.header|raw }}</header>
+  <h2>{{ title }}</h2>
+  <p>{{ body }}</p>
+  <footer>{{ slots.footer|raw }}</footer>
+</div>

--- a/example/components/card/component.yml
+++ b/example/components/card/component.yml
@@ -1,0 +1,13 @@
+props:
+  title:
+    type: string
+  body:
+    type: string
+slots:
+  header: {}
+  footer: {}
+libraries:
+  css:
+    - card.css
+  js:
+    - card.js

--- a/example/src/pages/index.astro
+++ b/example/src/pages/index.astro
@@ -1,4 +1,9 @@
 ---
-import Card from '../../components/card.twig';
+import Card from '../../components/card/card.twig';
+import Button from '../../components/button/button.twig';
+const button = await Button({ label: 'Click', url: '#' });
 ---
-<Card title="Hello" />
+<Card title="Hello" body="World">
+  <span slot="header">{button}</span>
+  <span slot="footer">Footer text</span>
+</Card>

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "type": "module",
   "dependencies": {
     "drupal-twig-extensions": "^1.0.0-beta.5",
+    "js-yaml": "^4.1.0",
     "twig": "^1.17.1"
   },
   "devDependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -21,10 +21,16 @@ export default function astroTwig(options = {}) {
         });
       },
     },
-    async render({ filename, data }) {
-      const tpl = await loader.load(filename);
-      const compiled = Twig.twig({ data: tpl, path: filename });
-      return compiled.render(data);
+    async render({ filename, props = {}, slots = {} }) {
+      const { template, spec, css, js } = await loader.load(filename);
+      loader.validate(spec, { props, slots });
+      const defaults = {};
+      for (const [key, info] of Object.entries(spec.props || {})) {
+        if (info.default !== undefined) defaults[key] = info.default;
+      }
+      const compiled = Twig.twig({ data: template, path: filename });
+      const html = compiled.render({ ...defaults, ...props, slots });
+      return { html, css, js };
     },
   };
 }

--- a/src/loader.js
+++ b/src/loader.js
@@ -1,5 +1,6 @@
 import { promises as fs } from 'fs';
 import path from 'path';
+import yaml from 'js-yaml';
 
 export default class DrupalTwigLoader {
   constructor(options = {}) {
@@ -21,9 +22,47 @@ export default class DrupalTwigLoader {
     for (const base of [...this.componentRoots, ...this.extraLookup]) {
       const file = path.join(base, target);
       try {
-        return await fs.readFile(file, 'utf8');
+        const template = await fs.readFile(file, 'utf8');
+        const dir = path.dirname(file);
+        const specPath = path.join(dir, 'component.yml');
+        let spec = {};
+        try {
+          const raw = await fs.readFile(specPath, 'utf8');
+          spec = yaml.load(raw) || {};
+        } catch (e) {}
+
+        const css = [];
+        for (const cssFile of spec.libraries?.css || []) {
+          try {
+            css.push(await fs.readFile(path.join(dir, cssFile), 'utf8'));
+          } catch (e) {}
+        }
+
+        const js = [];
+        for (const jsFile of spec.libraries?.js || []) {
+          try {
+            js.push(await fs.readFile(path.join(dir, jsFile), 'utf8'));
+          } catch (e) {}
+        }
+
+        return { template, spec, css, js };
       } catch (e) {}
     }
     throw new Error(`Template not found: ${target}`);
+  }
+
+  validate(spec, { props = {}, slots = {} }) {
+    const allowedProps = Object.keys(spec.props || {});
+    const allowedSlots = Object.keys(spec.slots || {});
+    for (const key of Object.keys(props)) {
+      if (!allowedProps.includes(key)) {
+        throw new Error(`Unknown prop: ${key}`);
+      }
+    }
+    for (const key of Object.keys(slots)) {
+      if (!allowedSlots.includes(key)) {
+        throw new Error(`Unknown slot: ${key}`);
+      }
+    }
   }
 }

--- a/tests/integration.test.js
+++ b/tests/integration.test.js
@@ -7,7 +7,20 @@ const siteRoot = path.join(process.cwd(), 'example');
 describe('astro-twig integration', () => {
   it('renders card component', async () => {
     const plugin = astroTwig({ componentRoots: [path.join(siteRoot, 'components')] });
-    const html = await plugin.render({ filename: 'card.twig', data: { title: 'Test' } });
-    expect(html.trim()).toBe('<div class="card">Test</div>');
+    const result = await plugin.render({ filename: 'card/card.twig', props: { title: 'Test', body: 'Body' }, slots: { header: 'Head', footer: 'Foot' } });
+    expect(result.html.trim()).toBe('<div class="card">\n  <header>Head</header>\n  <h2>Test</h2>\n  <p>Body</p>\n  <footer>Foot</footer>\n</div>');
+    expect(result.css.length).toBe(1);
+    expect(result.js.length).toBe(1);
+  });
+
+  it('allows nested component in slot', async () => {
+    const plugin = astroTwig({ componentRoots: [path.join(siteRoot, 'components')] });
+    const button = await plugin.render({ filename: 'button/button.twig', props: { label: 'Click', url: '#' } });
+    const card = await plugin.render({
+      filename: 'card/card.twig',
+      props: { title: 'Nested', body: 'Body' },
+      slots: { header: button.html, footer: 'End' }
+    });
+    expect(card.html).toContain('<a class="button" href="#">Click</a>');
   });
 });


### PR DESCRIPTION
## Summary
- support component metadata, JS, and CSS when loading Twig SDCs
- validate props and slots when rendering
- add example SDCs for card and button
- allow nested components in tests
- document nested invocation step

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6847248738ec8321806a071220a1f278